### PR TITLE
FIX: Add lapack as build dependency for ipopt 3.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   # TODO : Set the build number to 0 on the next cyipopt release.
-  number: 1002
+  number: 1003
   # TODO: Once ipopt is available for Windows in conda forge, remove the
   # following line.
   skip: True  # [win]
@@ -25,10 +25,12 @@ requirements:
   build:
     - pkg-config  # [osx]
     - {{ compiler('c') }}
+    - lapack
   host:
     - pip
     - python
-    - ipopt <3.13
+    - ipopt
+    - lapack
     - setuptools
     - cython
     - numpy
@@ -36,7 +38,7 @@ requirements:
     - six
   run:
     - python
-    - ipopt <3.13
+    - ipopt
     - {{ pin_compatible('numpy') }}
     - scipy
     - six

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
   build:
     - pkg-config  # [osx]
     - {{ compiler('c') }}
+    # NOTE : The conda-forge ipopt vendors lapack, thus it is needed explicitly.
     - lapack
   host:
     - pip


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #18
<!--
Please add any other relevant info below:
-->
Now that ipopt 3.13 is vendoring some dependencies, it appears at least one implicit dependency (lapack) that was getting pulled in by upstream conda-forge recipes is now missing. This fix adds lapack as an explicit build-time dependency, which seems to fix the build errors and allows the test to pass.